### PR TITLE
Introduced QoS property

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@ hue2mqtt
 ========
 
   Written and (C) 2015-16 Oliver Wagner <owagner@tellerulam.com> 
+  Additions (C) 2016 Christian Renz <crenz@web42.com>
+  
+  This is a fork of the original project implemented by Oliver Wagner.
+  Thank you for all the hard work, Oliver.
   
   Provided under the terms of the MIT license.
 
@@ -123,7 +127,7 @@ Dependencies
 * Minimal-JSON: https://github.com/ralfstx/minimal-json (used for JSON creation and parsing)
 * Philips HUE Java API Library: https://github.com/PhilipsHue/PhilipsHueSDK-Java-MultiPlatform-Android
 
-[![Build Status](https://travis-ci.org/owagner/hue2mqtt.svg)](https://travis-ci.org/owagner/hue2mqtt) Automatically built jars can be downloaded from the release page on GitHub at https://github.com/owagner/hue2mqtt/releases
+[![Build Status](https://travis-ci.org/crenz/hue2mqtt.svg?branch=master)](https://travis-ci.org/crenz/hue2mqtt) Automatically built jars of previous versions can be downloaded from the original release page on GitHub at https://github.com/owagner/hue2mqtt/releases
 
 
 History

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ When authentication is required, a one-shot not retained message is published to
 
   The topic prefix used for publishing and subscribing. Defaults to "knx/".
 
+- mqtt.qos
+
+  The quality of service used for publishing. Defaults to 0. Possible values are 0, 1, and 2.
+
 
 Dependencies
 ------------

--- a/src/main/java/com/tellerulam/hue2mqtt/HueHandler.java
+++ b/src/main/java/com/tellerulam/hue2mqtt/HueHandler.java
@@ -247,6 +247,7 @@ public class HueHandler implements PHSDKListener
 			 * Generate a JSON object with the state
 			 */
 			WrappedJsonObject json=new WrappedJsonObject();
+			json.add("val", state.isOn().booleanValue() ? state.getBrightness() : Integer.valueOf(0));
 			json.add("on",state.isOn());
 			json.add("bri",state.getBrightness());
 			json.add("hue",state.getHue());
@@ -264,11 +265,16 @@ public class HueHandler implements PHSDKListener
 				xy.add(state.getY().floatValue());
 				json.add("xy",xy);
 			}
-			MQTTHandler.publishIfChanged(
+/*			MQTTHandler.publishIfChanged(
 				"lights/"+l.getName(),
 				true,
 				"val", state.isOn().booleanValue() ? state.getBrightness() : Integer.valueOf(0),
 				"hue_state", json
+			); */
+			MQTTHandler.publishStringIfChanged(
+					"lights/"+l.getName(),
+					true,
+					json.toString()
 			);
 		}
 	}

--- a/src/main/java/com/tellerulam/hue2mqtt/MQTTHandler.java
+++ b/src/main/java/com/tellerulam/hue2mqtt/MQTTHandler.java
@@ -28,13 +28,31 @@ public class MQTTHandler
 	private static MQTTHandler instance;
 
 	private final String topicPrefix;
+
+	private static Integer qos;
+
 	private MQTTHandler()
 	{
 		String tp=System.getProperty("hue2mqtt.mqtt.topic","hue");
 		if(!tp.endsWith("/"))
 			tp+="/";
 		topicPrefix=tp;
-	}
+
+		qos = 0; // default QoS value
+
+		String s_qos = System.getProperty("hue2mqtt.mqtt.qos","hue");
+		if (s_qos != null) {
+            try {
+                qos = Integer.parseInt(s_qos);
+            } catch (NumberFormatException e) {
+
+            }
+        }
+
+        // Limit QoS value to range between 0 and 2
+        if (qos < 0) qos = 0;
+        if (qos > 2) qos = 2;
+    }
 
 	private MqttClient mqttc;
 
@@ -363,7 +381,7 @@ public class MQTTHandler
 		if(txtmsg.equals(previouslyPublishedValues.put(name,txtmsg)))
 			return;
 		MqttMessage msg=new MqttMessage(txtmsg.getBytes(StandardCharsets.UTF_8));
-		msg.setQos(0);
+		msg.setQos(qos);
 		msg.setRetained(retain);
 		try
 		{

--- a/src/main/java/com/tellerulam/hue2mqtt/MQTTHandler.java
+++ b/src/main/java/com/tellerulam/hue2mqtt/MQTTHandler.java
@@ -377,7 +377,11 @@ public class MQTTHandler
 			Object val=vals[pix+1];
 			jso.add(vname,val);
 		}
-		String txtmsg=jso.toString();
+		MQTTHandler.publishStringIfChanged(name, retain, jso.toString());
+	}
+
+	static void publishStringIfChanged(String name, boolean retain, String txtmsg)
+	{
 		if(txtmsg.equals(previouslyPublishedValues.put(name,txtmsg)))
 			return;
 		MqttMessage msg=new MqttMessage(txtmsg.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
Introduced new property „mqtt.qos“: The quality of service used for
publishing. Defaults to 0. Possible values are 0, 1, and 2.
