### PR TITLE
Removed << to work with Gradle 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 	)
 }
 
-task listJars << {
+task listJars {
     configurations.compile.each { File file -> println file.name }
 }
 


### PR DESCRIPTION
The << operator (leftShift) was deprecated in Gradle 4.10 and removed in Gradle 5. The build works if you just remove it.